### PR TITLE
Use unknown resource

### DIFF
--- a/lib/active_resource/base.rb
+++ b/lib/active_resource/base.rb
@@ -1603,7 +1603,7 @@ module ActiveResource
       def find_resource_in_object(resource_name)
         begin
           Object.const_get(resource_name, false)
-        rescue => exception
+        rescue
           create_unnamed_resource
         end
       end
@@ -1619,7 +1619,7 @@ module ActiveResource
         begin
           namespace = namespaces.reverse.detect { |ns| ns.const_defined?(*const_args) }
           namespace.const_get(*const_args)
-        rescue => exception
+        rescue
           create_unnamed_resource
         end
       end
@@ -1630,7 +1630,7 @@ module ActiveResource
         resource_name = name.to_s.camelize
         begin
           self.class.const_get(resource_name, false)
-        rescue => exception
+        rescue
           ancestors = self.class.name.to_s.split("::")
           if ancestors.size > 1
             find_resource_in_modules(resource_name, ancestors)
@@ -1685,11 +1685,6 @@ module ActiveResource
     include ActiveResource::Reflection
   end
 
-  # ActiveResource::UnnamedResource is a dummy class used when mapping
-  # resources fails to find a known resource class.
-  # class UnnamedResource < Base
-  # #   self.prefix = '/'
-  # end
 
   ActiveSupport.run_load_hooks(:active_resource, Base)
 end

--- a/lib/active_resource/base.rb
+++ b/lib/active_resource/base.rb
@@ -1449,14 +1449,14 @@ module ActiveResource
               resource = nil
               value.map do |attrs|
                 if attrs.is_a?(Hash)
-                  resource ||= find_or_create_resource_for_collection(key)
+                  resource ||= find_resource_for_collection(key)
                   resource.new(attrs, persisted)
                 else
                   attrs.duplicable? ? attrs.dup : attrs
                 end
               end
             when Hash
-              resource = find_or_create_resource_for(key)
+              resource = find_resource_for(key)
               resource.new(value, persisted)
             else
               value.duplicable? ? value.dup : value
@@ -1594,54 +1594,50 @@ module ActiveResource
       end
 
       # Tries to find a resource for a given collection name; if it fails, then the resource is created
-      def find_or_create_resource_for_collection(name)
+      def find_resource_for_collection(name)
         return reflections[name.to_sym].klass if reflections.key?(name.to_sym)
-        find_or_create_resource_for(ActiveSupport::Inflector.singularize(name.to_s))
+        find_resource_for(ActiveSupport::Inflector.singularize(name.to_s))
+      end
+
+      # Tries to find a resource in Object, if it fails, then UnnamedResource is used instead
+      def find_resource_in_object(resource_name)
+        begin
+          Object.const_get(resource_name, false)
+        rescue => exception
+          UnnamedResource
+        end
       end
 
       # Tries to find a resource in a non empty list of nested modules
       # if it fails, then the resource is created
-      def find_or_create_resource_in_modules(resource_name, module_names)
+      def find_resource_in_modules(resource_name, module_names)
         receiver = Object
         namespaces = module_names[0, module_names.size-1].map do |module_name|
           receiver = receiver.const_get(module_name)
         end
         const_args = [resource_name, false]
-        if namespace = namespaces.reverse.detect { |ns| ns.const_defined?(*const_args) }
+        begin
+          namespace = namespaces.reverse.detect { |ns| ns.const_defined?(*const_args) }
           namespace.const_get(*const_args)
-        else
-          create_resource_for(resource_name)
+        rescue => exception
+          UnnamedResource
         end
       end
 
-      # Tries to find a resource for a given name; if it fails, then the resource is created
-      def find_or_create_resource_for(name)
+      # Tries to find a resource for a given name; if it fails, then UnnamedResource is used instead
+      def find_resource_for(name)
         return reflections[name.to_sym].klass if reflections.key?(name.to_sym)
         resource_name = name.to_s.camelize
-
-        const_args = [resource_name, false]
-        if self.class.const_defined?(*const_args)
-          self.class.const_get(*const_args)
-        else
+        begin
+          self.class.const_get(resource_name, false)
+        rescue => exception
           ancestors = self.class.name.to_s.split("::")
           if ancestors.size > 1
-            find_or_create_resource_in_modules(resource_name, ancestors)
+            find_resource_in_modules(resource_name, ancestors)
           else
-            if Object.const_defined?(*const_args)
-              Object.const_get(*const_args)
-            else
-              create_resource_for(resource_name)
-            end
+          find_resource_in_object(resource_name)
           end
         end
-      end
-
-      # Create and return a class definition for a resource inside the current resource
-      def create_resource_for(resource_name)
-        resource = self.class.const_set(resource_name, Class.new(ActiveResource::Base))
-        resource.prefix = self.class.prefix
-        resource.site   = self.class.site
-        resource
       end
 
       def split_options(options = {})
@@ -1676,6 +1672,12 @@ module ActiveResource
     include ActiveModel::Serializers::JSON
     include ActiveModel::Serializers::Xml
     include ActiveResource::Reflection
+  end
+
+  # ActiveResource::UnnamedResource is a dummy class used when mapping
+  # resources fails to find a known resource class.
+  class UnnamedResource < Base
+    self.prefix = '/'
   end
 
   ActiveSupport.run_load_hooks(:active_resource, Base)

--- a/lib/active_resource/base.rb
+++ b/lib/active_resource/base.rb
@@ -1604,7 +1604,7 @@ module ActiveResource
         begin
           Object.const_get(resource_name, false)
         rescue => exception
-          UnnamedResource
+          create_unnamed_resource
         end
       end
 
@@ -1620,7 +1620,7 @@ module ActiveResource
           namespace = namespaces.reverse.detect { |ns| ns.const_defined?(*const_args) }
           namespace.const_get(*const_args)
         rescue => exception
-          UnnamedResource
+          create_unnamed_resource
         end
       end
 
@@ -1638,6 +1638,17 @@ module ActiveResource
           find_resource_in_object(resource_name)
           end
         end
+      end
+
+      def create_unnamed_resource
+        if self.class.const_defined?(:UnnamedResource, false)
+          resource = self.class.const_get(:UnnamedResource, false)
+        else
+          resource = self.class.const_set(:UnnamedResource, Class.new(ActiveResource::Base))
+        end
+        resource.prefix = self.class.prefix
+        resource.site   = self.class.site
+        resource
       end
 
       def split_options(options = {})
@@ -1676,9 +1687,9 @@ module ActiveResource
 
   # ActiveResource::UnnamedResource is a dummy class used when mapping
   # resources fails to find a known resource class.
-  class UnnamedResource < Base
-    self.prefix = '/'
-  end
+  # class UnnamedResource < Base
+  # #   self.prefix = '/'
+  # end
 
   ActiveSupport.run_load_hooks(:active_resource, Base)
 end

--- a/test/cases/base_test.rb
+++ b/test/cases/base_test.rb
@@ -1382,11 +1382,11 @@ class BaseTest < ActiveSupport::TestCase
     luis = Customer.find(1)
     assert_kind_of Customer, luis
     luis.friends.each do |friend|
-      assert_kind_of Customer::Friend, friend
+      assert_kind_of Customer::UnnamedResource, friend
       friend.brothers.each do |brother|
-        assert_kind_of Customer::Friend::Brother, brother
+        assert_kind_of Customer::UnnamedResource::UnnamedResource, brother
         brother.children.each do |child|
-          assert_kind_of Customer::Friend::Brother::Child, child
+          assert_kind_of Customer::UnnamedResource::UnnamedResource::UnnamedResource, child
         end
       end
     end
@@ -1494,7 +1494,7 @@ class BaseTest < ActiveSupport::TestCase
 
   def test_namespacing
     sound = Asset::Sound.find(1)
-    assert_equal "Asset::Sound::Author", sound.author.class.to_s
+    assert_equal "Asset::Sound::UnnamedResource", sound.author.class.to_s
   end
 
   def test_paths_with_format


### PR DESCRIPTION
Converting response hash keys into constants can cause issues. If the key contains anything but letters and numbers, ruby will throw a `NameError: wrong constant name` error. You could strip out special characters and replace them with underscores or just remove them, but if the response keys begin with a number, you will still get the same error (and stripping a number is arguably harder to do).

If a resource is unnamed, we weren't expecting it, so treat it as an anonymous class and reuse the same anonymous class. 